### PR TITLE
Candidate name autofocus fix

### DIFF
--- a/components/CandidateInputList.tsx
+++ b/components/CandidateInputList.tsx
@@ -31,7 +31,10 @@ const CandidateInputList = (props: Props) => {
   };
 
   const setFocusToLastCandidate = useCallback(() => {
-    const lastCandidateTextInput = document.querySelectorAll('.' + props.textFieldClassName + ':last-of-type input')[0] as HTMLInputElement;
+    // Query selecting the textFieldClassName with last-of-type will return all
+    // the candidate input boxes instead of just the last one.
+    // The at(-1) ensure the last input is returned
+    const lastCandidateTextInput = Array.from(document.querySelectorAll('.' + props.textFieldClassName + ':last-of-type input')).at(-1) as HTMLInputElement;
     if (lastCandidateTextInput && lastCandidateTextInput.focus) {
       lastCandidateTextInput.focus();
     }


### PR DESCRIPTION
Fixes the autofix bug.
Without this, the first candidate input is the one that always gets focused.
The other textbox on the page (Question input) causes the last-of-type to be _all_ of the candidate input boxes instead of just the last one. So using `.at(-1)` ensures the last one gets selected

If there's a better way to do this autofocus lmk.

Relevant docs:
https://developer.mozilla.org/en-US/docs/Web/CSS/:last-of-type

Tested manually via localhost